### PR TITLE
feat(scraping): 持続セッション方式の下地を追加（デフォルトOFF・512MB運用）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,13 @@ COOKIE_PERSIST_ENABLED=true
 REFERER_STRATEGY=direct
 AUTH_COOLDOWN_MINUTES=15
 
+# 持続セッション（突破済みブラウザを維持・デフォルトOFF）
+# ONにすると5分ごとに同一ブラウザ/タブでreloadし、認証を避けて軽量確認します
+PERSISTENT_BROWSER_ENABLED=false
+PERSISTENT_BROWSER_TTL_MINUTES=120   # セッション寿命（分）
+AUTH_CONSECUTIVE_MAX=2               # 認証検出が連続したらセッション再生成
+BLOCK_MEDIA_RESOURCES=true           # 画像・動画などをブロックして軽量化
+
 # マルチユーザーモード設定
 MULTI_USER_MODE=false
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,10 +31,10 @@ services:
     deploy:
       resources:
         limits:
-          memory: 256M
+          memory: 512M
           cpus: '0.5'
         reservations:
-          memory: 128M
+          memory: 256M
           cpus: '0.25'
 
   cloudflared:

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,6 +27,11 @@ export const config: Config = {
   },
   scraping: {
     strategy: process.env.SCRAPE_STRATEGY === 'http_first' ? 'http_first' : 'puppeteer_first',
+    // デフォルトはOFF（運用で明示的にONにする）
+    persistentSessionEnabled: process.env.PERSISTENT_BROWSER_ENABLED === 'true',
+    sessionTtlMinutes: parseInt(process.env.PERSISTENT_BROWSER_TTL_MINUTES ?? '120', 10),
+    maxConsecutiveAuth: parseInt(process.env.AUTH_CONSECUTIVE_MAX ?? '2', 10),
+    blockMediaResources: process.env.BLOCK_MEDIA_RESOURCES !== 'false',
   },
   app: {
     port: parseInt(process.env.PORT ?? '3000', 10),

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,6 +110,10 @@ export interface Config {
   };
   scraping?: {
     strategy: 'puppeteer_first' | 'http_first';
+    persistentSessionEnabled?: boolean;
+    sessionTtlMinutes?: number;
+    maxConsecutiveAuth?: number;
+    blockMediaResources?: boolean;
   };
   app: {
     port: number;

--- a/src/utils/session-manager.ts
+++ b/src/utils/session-manager.ts
@@ -1,0 +1,183 @@
+import puppeteer from 'puppeteer-extra';
+import StealthPlugin from 'puppeteer-extra-plugin-stealth';
+import type { Browser, BrowserContext, Page } from 'puppeteer';
+import { vibeLogger } from '../logger.js';
+import { config } from '../config.js';
+
+puppeteer.use(StealthPlugin());
+
+type SessionState = {
+  browser?: Browser;
+  context?: BrowserContext;
+  page?: Page;
+  createdAt?: number;
+  consecutiveAuth: number;
+};
+
+class SessionManager {
+  private state: SessionState = { consecutiveAuth: 0 };
+
+  private get ttlMs(): number {
+    const minutes = config.scraping?.sessionTtlMinutes ?? 120;
+    return Math.max(1, minutes) * 60 * 1000;
+  }
+
+  private get maxAuth(): number {
+    return Math.max(1, config.scraping?.maxConsecutiveAuth ?? 2);
+  }
+
+  private shouldBlockMedia(): boolean {
+    return !!config.scraping?.blockMediaResources;
+  }
+
+  private async ensureSession(warmupUrl: string): Promise<Page> {
+    const now = Date.now();
+    const expired = this.state.createdAt ? now - this.state.createdAt > this.ttlMs : true;
+    const missing = !this.state.browser || !this.state.context || !this.state.page;
+
+    if (missing || expired) {
+      await this.recreateSession(warmupUrl);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    return this.state.page!;
+  }
+
+  private async recreateSession(warmupUrl: string): Promise<void> {
+    await this.destroy().catch(() => undefined);
+    this.state = { consecutiveAuth: 0 };
+
+    const browser = await puppeteer.launch({
+      headless: true,
+      args: [
+        '--no-sandbox',
+        '--disable-setuid-sandbox',
+        '--disable-dev-shm-usage',
+        '--disable-gpu',
+        '--disable-blink-features=AutomationControlled',
+        '--window-size=1280,800',
+      ],
+      protocolTimeout: 120000,
+    });
+    const context = await browser.createBrowserContext();
+    const page = await context.newPage();
+
+    if (this.shouldBlockMedia()) {
+      await page.setRequestInterception(true);
+      page.on('request', req => {
+        const rtype = req.resourceType();
+        if (rtype === 'image' || rtype === 'media' || rtype === 'font') {
+          void req.abort();
+          return;
+        }
+        const url = req.url();
+        if (/\.(png|jpe?g|gif|svg|webp|ico)(\?|$)/i.test(url)) {
+          void req.abort();
+          return;
+        }
+        void req.continue();
+      });
+    }
+
+    await page.setUserAgent(
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'
+    );
+    await page.setViewport({ width: 1280, height: 800, deviceScaleFactor: 1 });
+    page.setDefaultTimeout(60000);
+    page.setDefaultNavigationTimeout(60000);
+
+    // 軽いウォームアップ
+    try {
+      await page.goto('https://www.google.com', { waitUntil: 'domcontentloaded' });
+      await new Promise(r => setTimeout(r, 800));
+    } catch (e) {
+      vibeLogger.debug('session.warmup.google_failed', 'Googleウォームアップ失敗', {
+        context: { error: e instanceof Error ? e.message : String(e) },
+      });
+    }
+    try {
+      await page.goto(warmupUrl, { waitUntil: 'domcontentloaded' });
+    } catch (e) {
+      vibeLogger.debug('session.warmup.target_failed', '対象URLウォームアップ失敗', {
+        context: { error: e instanceof Error ? e.message : String(e) },
+      });
+    }
+
+    this.state.browser = browser;
+    this.state.context = context;
+    this.state.page = page;
+    this.state.createdAt = Date.now();
+
+    vibeLogger.info('session.created', '持続セッションを作成しました', {
+      context: { ttlMinutes: this.ttlMs / 60000 },
+    });
+  }
+
+  private async softHumanize(page: Page): Promise<void> {
+    try {
+      await page.evaluate(() => window.scrollTo(0, 200));
+      await new Promise(r => setTimeout(r, 400));
+    } catch (e) {
+      vibeLogger.debug('session.humanize_failed', '自然化操作の実行に失敗', {
+        context: { error: e instanceof Error ? e.message : String(e) },
+      });
+    }
+  }
+
+  private isAuthPage(title: string, contentSnippet: string): boolean {
+    return title.includes('認証') || /認証にご協力ください|verify|challenge/i.test(contentSnippet);
+  }
+
+  async reloadAndGetContent(
+    url: string
+  ): Promise<{ title: string; html: string; authDetected: boolean }> {
+    const page = await this.ensureSession(url);
+
+    try {
+      const currentUrl = page.url();
+      if (currentUrl && new URL(currentUrl).href === new URL(url).href) {
+        await page.reload({ waitUntil: 'domcontentloaded' });
+      } else {
+        await page.goto(url, { waitUntil: 'domcontentloaded' });
+      }
+      await this.softHumanize(page);
+    } catch (e) {
+      vibeLogger.debug('session.reload_failed', 'reload/gotoの実行に失敗', {
+        context: { error: e instanceof Error ? e.message : String(e), url },
+      });
+    }
+
+    const title = await page.title().catch(() => '');
+    const html = await page.content().catch(() => '');
+    const auth = this.isAuthPage(title, html.slice(0, 2000));
+
+    if (auth) {
+      this.state.consecutiveAuth += 1;
+      vibeLogger.warn('session.auth_detected', '認証ページを検出しました', {
+        context: { consecutiveAuth: this.state.consecutiveAuth, max: this.maxAuth },
+      });
+      if (this.state.consecutiveAuth >= this.maxAuth) {
+        vibeLogger.info('session.recreate', '連続認証検出のためセッションを再生成します');
+        await this.recreateSession(url);
+      }
+    } else {
+      this.state.consecutiveAuth = 0;
+    }
+
+    return { title, html, authDetected: auth };
+  }
+
+  async destroy(): Promise<void> {
+    const b = this.state.browser;
+    this.state = { consecutiveAuth: 0 };
+    try {
+      await b?.close();
+    } catch (e) {
+      vibeLogger.debug('session.destroy_failed', 'ブラウザクローズでエラー', {
+        context: { error: e instanceof Error ? e.message : String(e) },
+      });
+    }
+  }
+}
+
+export const sessionManager = new SessionManager();


### PR DESCRIPTION
## 目的

監視の成功率と安定性を高めるため、突破済みブラウザを維持して5分ごとに軽量に再確認できる「持続セッション方式」の下地を追加します。再認証が発生しやすい環境でも、突破後のセッションを活かして安定運用することを狙いとします。

## 変更概要

- 新規: 持続セッション管理 `SessionManager` を追加（src/utils/session-manager.ts）
  - 同一 Browser/Context/Page を維持
  - TTL（既定120分）超過で再生成
  - 認証ページ検出の連続回数（既定2回）で再生成
  - 画像/動画/フォントのブロックで軽量化
  - 軽い自然化（スクロール＋短待機）とウォームアップ（Google→対象）
- Scraper配線（フラグON時のみ）
  - `SimpleScraper` がまず持続セッションで `reload` 取得→cheerioで軽量抽出
  - 失敗/認証検出時は `PuppeteerScraper` にフォールバック
- 設定フラグ（.env.example へ追記、既定OFF）
  - `PERSISTENT_BROWSER_ENABLED=false`
  - `PERSISTENT_BROWSER_TTL_MINUTES=120`
  - `AUTH_CONSECUTIVE_MAX=2`
  - `BLOCK_MEDIA_RESOURCES=true`
- リソース前提
  - `docker-compose.yml` のメモリ上限を 512MB に引き上げ（1タブ運用を想定）

## 挙動と互換性

- 既定はOFFのため、従来の挙動・CIともに非影響（完全後方互換）
- フラグON時のみ持続セッション経由の軽量確認→失敗時に既存Puppeteerへフォールバック

## 有効化方法（開発/本番）

1) `.env` / `.env.production` に以下を追加
```
PERSISTENT_BROWSER_ENABLED=true
PERSISTENT_BROWSER_TTL_MINUTES=120
AUTH_CONSECUTIVE_MAX=2
BLOCK_MEDIA_RESOURCES=true
```
2) Dockerメモリ上限（512MB）で起動
```
docker compose up -d sokubutsu-mvp
```

## 検証観点

- ログで以下を確認
  - `session.created`: セッション生成
  - `scraping.success.persistent`: 持続セッションでの抽出成功
  - `session.auth_detected`: 認証ページ検出（連続数）
  - `session.recreate`: 連続認証に伴う再生成
- Telegram `/check` が応答し、失敗が続く際にもフォールバックで監視継続

## リスク/留意点

- メモリ: 1タブあたり 150–250MB 目安（遮断込み）。複数URLは段階導入
- 長寿命セッションの“毒化”に対し、TTL/連続認証の再生成ルールで自動回復
- 監視対象が増える場合はタブプール/レート制御が必要（次段で対応）

## 今後（段階導入計画）

- フェーズ2: 複数URL向けタブプール（上限2–3）と負荷調整
- フェーズ3: 連続失敗時のみ Real Browser フォールバック（重いため常用は避ける）
- 運用補助: `/session reset` コマンド追加（手動で再生成）

## 変更ファイル（主なもの）

- `src/utils/session-manager.ts`: 新規（持続セッション）
- `src/scraper.ts`: フラグON時のセッション利用→抽出→フォールバック
- `.env.example`: フラグ群追加
- `docker-compose.yml`: メモリ上限 512MB

